### PR TITLE
[EMM-1196] generate certs if pd-kafka ssl enabled

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,6 +45,10 @@ default["apache_kafka"]["broker.id"] = nil
 default["apache_kafka"]["port"] = 9092
 default["apache_kafka"]["zookeeper.connect"] = nil
 
+# execute kafka bin dir pd-generate-certs script on upstart pre-start if true
+# see pd-kafka ssl recipe for deets
+default["apache_kafka"]["pd_generate_certs"] = false
+
 # Check in /var/log/kafka/server.log for invalid entries
 #
 default["apache_kafka"]["conf"]["server"] = {

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -50,7 +50,9 @@ when "upstart"
     action :create
     mode "0644"
     variables(
-      :kafka_umask => sprintf("%#03o", node["apache_kafka"]["umask"])
+      :kafka_umask => sprintf("%#03o", node["apache_kafka"]["umask"]),
+      :pd_generate_certs => node["apache_kafka"]["pd_generate_certs"],
+      :kafka_bin_dir => node['apache_kafka']['bin_dir']
     )
     notifies :restart, "service[kafka]", :delayed if do_restart
   end

--- a/templates/default/kafka.init.erb
+++ b/templates/default/kafka.init.erb
@@ -14,7 +14,11 @@ umask <%= @kafka_umask %>
 kill timeout 300
 
 pre-start script
+<% if @pd_generate_certs -%>
+    [ -r /etc/default/kafka ] && <%= @kafka_bin_dir %>/pd-generate-certs.sh
+<% else -%>
     [ -r /etc/default/kafka ]
+<% end -%>
 end script
 
 limit nofile 32768 32768
@@ -24,4 +28,3 @@ script
   exec start-stop-daemon --start --chuid ${KAFKA_USER} --name ${KAFKA_USER} \
     --exec ${KAFKA_BIN}/kafka-server-start.sh -- ${KAFKA_CONFIG}/server.properties
 end script
-


### PR DESCRIPTION
Provides optional SSL cert generation on upstart.pre-start via pd-kafka cookbook supplied pd-generate-certs script

@chamblin 