### PR TITLE
[EMM-1196] read keystore pass from vault

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,9 +45,11 @@ default["apache_kafka"]["broker.id"] = nil
 default["apache_kafka"]["port"] = 9092
 default["apache_kafka"]["zookeeper.connect"] = nil
 
-# execute kafka bin dir pd-generate-certs script on upstart pre-start if true
-# see pd-kafka ssl recipe for deets
-default["apache_kafka"]["pd_generate_certs"] = false
+### These attributes are passed through from the pd-vault:ssl recipe
+# Execute kafka bin dir pd-generate-certs script on upstart pre-start if true
+default["apache_kafka"]["ssl"]["pd_generate_certs"] = false
+# The vault_app_id used for reading the keystore_pass from vault
+default["apache_kafka"]["ssl"]["vault_app_id"] = "unknown"
 
 # Check in /var/log/kafka/server.log for invalid entries
 #

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,3 +14,6 @@ end
 
 depends "java"
 depends "runit"
+
+# This is a dependency but commented out due to issues with Berksfile in chef repo
+# depends "pdbase"

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -37,6 +37,19 @@ broker_id = 0 if broker_id.nil?
 zookeeper_connect = node["apache_kafka"]["zookeeper.connect"]
 zookeeper_connect = "localhost:2181" if zookeeper_connect.nil?
 
+# read keystore_pass from vault if pd_generate_certs is true
+keystore_pass = nil
+if node["apache_kafka"]["ssl"]["pd_generate_certs"]
+  vault_app_id = node["apache_kafka"]["ssl"]["vault_app_id"]
+  begin
+    node.pd_helper.with_vault_availability(vault_app_id) do |vault_client|
+      keystore_pass = vault_client.read("secret/#{vault_app_id}/keystore", "password")
+    end
+  rescue PagerDuty::V2::VaultAuthError => e
+    Chef::Log.warn("Unable to authenticate with Vault: #{e.message}")
+  end
+end
+
 template ::File.join(node["apache_kafka"]["config_dir"],
                      node["apache_kafka"]["conf"]["server"]["file"]) do
   source "properties/server.properties.erb"
@@ -48,9 +61,11 @@ template ::File.join(node["apache_kafka"]["config_dir"],
     :port => node["apache_kafka"]["port"],
     :zookeeper_connect => zookeeper_connect,
     :log_dirs => node["apache_kafka"]["data_dir"],
-    :entries => node["apache_kafka"]["conf"]["server"]["entries"]
+    :entries => node["apache_kafka"]["conf"]["server"]["entries"],
+    :keystore_pass => keystore_pass
   )
   notifies :restart, "service[kafka]", :delayed if do_restart
+  sensitive true
 end
 
 template ::File.join(node["apache_kafka"]["config_dir"],

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -51,7 +51,7 @@ when "upstart"
     mode "0644"
     variables(
       :kafka_umask => sprintf("%#03o", node["apache_kafka"]["umask"]),
-      :pd_generate_certs => node["apache_kafka"]["pd_generate_certs"],
+      :pd_generate_certs => node["apache_kafka"]["ssl"]["pd_generate_certs"],
       :kafka_bin_dir => node['apache_kafka']['bin_dir']
     )
     notifies :restart, "service[kafka]", :delayed if do_restart

--- a/templates/default/properties/server.properties.erb
+++ b/templates/default/properties/server.properties.erb
@@ -9,3 +9,8 @@ log.dirs=<%= @log_dirs %>
 <%- @entries.each do |k, v| %>
 <%= k %>=<%= v %>
 <%- end %>
+
+<% if @keystore_pass %>
+ssl.keystore.password=<%= @keystore_pass %>
+ssl.truststore.password=<%= @keystore_pass %>
+<% end %>


### PR DESCRIPTION
Wrapper cookbook recipe `pd-vault:ssl` was passing plaintext keystore password through to this cookbook by setting a node attribute which could be read with a chef search.  This change will read the password directly from vault.