### PR TITLE
Allow configuration of JAVA_HOME

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,7 @@ default["apache_kafka"]["jmx"]["port"] = ""
 default["apache_kafka"]["jmx"]["opts"] = "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
 
 default["apache_kafka"]["install_java"] = true
+default["apache_kafka"]["java_home"] = ""
 
 default["apache_kafka"]["install_dir"] = "/usr/local/kafka"
 default["apache_kafka"]["data_dir"] = "/var/log/kafka"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email "mathyourlife@gmail.com"
 license          "Apache-2.0"
 description      "Installs/Configures Apache Kafka >= 0.7.0"
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
-version          "0.0.2"
+version          "0.0.3"
 
 %w{ ubuntu debian }.each do |os|
   supports os

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -38,7 +38,8 @@ template "/etc/default/kafka" do
     :kafka_jvm_performance_opts => node["apache_kafka"]["kafka_jvm_performance_opts"],
     :kafka_opts => node["apache_kafka"]["kafka_opts"],
     :jmx_port => node["apache_kafka"]["jmx"]["port"],
-    :jmx_opts => node["apache_kafka"]["jmx"]["opts"]
+    :jmx_opts => node["apache_kafka"]["jmx"]["opts"],
+    :java_home => node["apache_kafka"]["java_home"]
   )
   notifies :restart, "service[kafka]", :delayed if do_restart
 end

--- a/templates/default/kafka_env.erb
+++ b/templates/default/kafka_env.erb
@@ -10,6 +10,7 @@ export KAFKA_CONFIG="<%= @kafka_config %>"
 export KAFKA_BIN="<%= @kafka_bin %>"
 
 # Which java to use
+export JAVA_HOME="<%= @java_home %>"
 if [ -z "$JAVA_HOME" ]; then
   export JAVA="java"
 else


### PR DESCRIPTION
In order to allow us more control of how we install java, allow
configuration of JAVA_HOME